### PR TITLE
remove platform defines

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -62,9 +62,6 @@
 /*
  * Malloc debugging stuff.
  */
-#if defined(sun)
-#undef MALLOC_DEBUG
-#endif
 
 #if defined(MALLOC_DEBUG)
 #include <malloc.h>
@@ -74,26 +71,14 @@ extern int malloc_verify args((void));
 
 /*
  * Signal handling.
- * Apollo has a problem with __attribute(atomic) in signal.h,
- *   I dance around it.
  */
-#if defined(apollo)
-#define __attribute(x)
-#endif
 
-#if defined(unix)
 #include <signal.h>
-#endif
-
-#if defined(apollo)
-#undef __attribute
-#endif
 
 /*
  * Socket and TCP/IP stuff.
  */
 
-#if defined(unix)
 #include <fcntl.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -103,139 +88,6 @@ extern int malloc_verify args((void));
 const char echo_off_str[] = {IAC, WILL, TELOPT_ECHO, '\0'};
 const char echo_on_str[] = {IAC, WONT, TELOPT_ECHO, '\0'};
 const char go_ahead_str[] = {IAC, GA, '\0'};
-#endif
-
-/*
- * OS-dependent declarations.
- */
-
-#if defined(_AIX)
-#include <sys/select.h>
-int accept args((int s, struct sockaddr *addr, int *addrlen));
-int bind args((int s, struct sockaddr *name, int namelen));
-void bzero args((char *b, int length));
-int getpeername args((int s, struct sockaddr *name, int *namelen));
-int getsockname args((int s, struct sockaddr *name, int *namelen));
-int gettimeofday args((struct timeval * tp, struct timezone *tzp));
-int listen args((int s, int backlog));
-int setsockopt args((int s, int level, int optname, void *optval, int optlen));
-int socket args((int domain, int type, int protocol));
-#endif
-
-#if defined(apollo)
-#include <unistd.h>
-void bzero args((char *b, int length));
-#endif
-
-#if defined(__hpux)
-int accept args((int s, void *addr, int *addrlen));
-int bind args((int s, const void *addr, int addrlen));
-void bzero args((char *b, int length));
-int getpeername args((int s, void *addr, int *addrlen));
-int getsockname args((int s, void *name, int *addrlen));
-int gettimeofday args((struct timeval * tp, struct timezone *tzp));
-int listen args((int s, int backlog));
-int setsockopt args((int s, int level, int optname, const void *optval,
-                     int optlen));
-int socket args((int domain, int type, int protocol));
-#endif
-
-#if defined(interactive)
-#include <net/errno.h>
-#include <sys/fnctl.h>
-#endif
-
-#if defined(MIPS_OS)
-extern int errno;
-#endif
-
-#if defined(MSDOS)
-int gettimeofday args((struct timeval * tp, void *tzp));
-int kbhit args((void));
-#endif
-
-#if defined(NeXT)
-int close args((int fd));
-int fcntl args((int fd, int cmd, int arg));
-#if !defined(htons)
-u_short htons args((u_short hostshort));
-#endif
-#if !defined(ntohl)
-u_long ntohl args((u_long hostlong));
-#endif
-int read args((int fd, char *buf, int nbyte));
-int select args((int width, fd_set *readfds, fd_set *writefds,
-                 fd_set *exceptfds, struct timeval *timeout));
-int write args((int fd, char *buf, int nbyte));
-#endif
-
-#if defined(sequent)
-int accept args((int s, struct sockaddr *addr, int *addrlen));
-int bind args((int s, struct sockaddr *name, int namelen));
-int close args((int fd));
-int fcntl args((int fd, int cmd, int arg));
-int getpeername args((int s, struct sockaddr *name, int *namelen));
-int getsockname args((int s, struct sockaddr *name, int *namelen));
-int gettimeofday args((struct timeval * tp, struct timezone *tzp));
-#if !defined(htons)
-u_short htons args((u_short hostshort));
-#endif
-int listen args((int s, int backlog));
-#if !defined(ntohl)
-u_long ntohl args((u_long hostlong));
-#endif
-int read args((int fd, char *buf, int nbyte));
-int select args((int width, fd_set *readfds, fd_set *writefds,
-                 fd_set *exceptfds, struct timeval *timeout));
-int setsockopt args((int s, int level, int optname, caddr_t optval,
-                     int optlen));
-int socket args((int domain, int type, int protocol));
-int write args((int fd, char *buf, int nbyte));
-#endif
-
-/* This includes Solaris Sys V as well */
-#if defined(sun)
-int accept args((int s, struct sockaddr *addr, int *addrlen));
-int bind args((int s, struct sockaddr *name, int namelen));
-void bzero args((char *b, int length));
-int close args((int fd));
-int getpeername args((int s, struct sockaddr *name, int *namelen));
-int getsockname args((int s, struct sockaddr *name, int *namelen));
-int listen args((int s, int backlog));
-int read args((int fd, char *buf, int nbyte));
-int select args((int width, fd_set *readfds, fd_set *writefds,
-                 fd_set *exceptfds, struct timeval *timeout));
-
-#if !defined(__SVR4)
-int gettimeofday args((struct timeval * tp, struct timezone *tzp));
-
-#if defined(SYSV)
-int setsockopt args((int s, int level, int optname, const char *optval,
-                     int optlen));
-#else
-int setsockopt args((int s, int level, int optname, void *optval, int optlen));
-#endif
-#endif
-int socket args((int domain, int type, int protocol));
-int write args((int fd, char *buf, int nbyte));
-#endif
-
-#if defined(ultrix)
-int accept args((int s, struct sockaddr *addr, int *addrlen));
-int bind args((int s, struct sockaddr *name, int namelen));
-void bzero args((char *b, int length));
-int close args((int fd));
-int getpeername args((int s, struct sockaddr *name, int *namelen));
-int getsockname args((int s, struct sockaddr *name, int *namelen));
-int gettimeofday args((struct timeval * tp, struct timezone *tzp));
-int listen args((int s, int backlog));
-int read args((int fd, char *buf, int nbyte));
-int select args((int width, fd_set *readfds, fd_set *writefds,
-                 fd_set *exceptfds, struct timeval *timeout));
-int setsockopt args((int s, int level, int optname, void *optval, int optlen));
-int socket args((int domain, int type, int protocol));
-int write args((int fd, char *buf, int nbyte));
-#endif
 
 /*
  * Global variables.
@@ -254,13 +106,11 @@ time_t current_time; /* time of this pulse */
  * OS-dependent local functions.
  */
 
-#if defined(unix)
 void game_loop_unix args((int control));
 int init_socket args((int port));
 void init_descriptor args((int control));
 bool read_from_descriptor args((DESCRIPTOR_DATA * d));
 bool write_to_descriptor args((int desc, char *txt, int length));
-#endif
 
 /*
  * Other local functions (OS-independent).
@@ -279,9 +129,7 @@ int main(int argc, char **argv) {
   struct timeval now_time;
   int port;
 
-#if defined(unix)
   int control;
-#endif
 
   /*
    * Memory debugging if needed.
@@ -323,14 +171,12 @@ int main(int argc, char **argv) {
    * Run the game.
    */
 
-#if defined(unix)
   control = init_socket(port);
   boot_db();
   sprintf(log_buf, "ROM is ready to rock on port %d.", port);
   log_string(log_buf);
   game_loop_unix(control);
   close(control);
-#endif
 
   /*
    * That's all, folks.
@@ -340,7 +186,6 @@ int main(int argc, char **argv) {
   return 0;
 }
 
-#if defined(unix)
 int init_socket(int port) {
   static struct sockaddr_in sa_zero;
   struct sockaddr_in sa;
@@ -357,22 +202,6 @@ int init_socket(int port) {
     close(fd);
     exit(1);
   }
-
-#if defined(SO_DONTLINGER) && !defined(SYSV)
-  {
-    struct linger ld;
-
-    ld.l_onoff = 1;
-    ld.l_linger = 1000;
-
-    if (setsockopt(fd, SOL_SOCKET, SO_DONTLINGER, (char *)&ld, sizeof(ld)) <
-        0) {
-      perror("Init_socket: SO_DONTLINGER");
-      close(fd);
-      exit(1);
-    }
-  }
-#endif
 
   sa = sa_zero;
   sa.sin_family = AF_INET;
@@ -392,9 +221,7 @@ int init_socket(int port) {
 
   return fd;
 }
-#endif
 
-#if defined(unix)
 void game_loop_unix(int control) {
   static struct timeval null_time;
   struct timeval last_time;
@@ -568,9 +395,7 @@ void game_loop_unix(int control) {
 
   return;
 }
-#endif
 
-#if defined(unix)
 void init_descriptor(int control) {
   char buf[MAX_STRING_LENGTH];
   DESCRIPTOR_DATA *dnew;
@@ -585,10 +410,6 @@ void init_descriptor(int control) {
     perror("New_descriptor: accept");
     return;
   }
-
-#if !defined(FNDELAY)
-#define FNDELAY O_NDELAY
-#endif
 
   if (fcntl(desc, F_SETFL, FNDELAY) == -1) {
     perror("New_descriptor: fcntl: FNDELAY");
@@ -665,7 +486,6 @@ void init_descriptor(int control) {
 
   return;
 }
-#endif
 
 void close_socket(DESCRIPTOR_DATA *dclose) {
   CHAR_DATA *ch;
@@ -733,7 +553,6 @@ bool read_from_descriptor(DESCRIPTOR_DATA *d) {
 
   /* Snarf input. */
 
-#if defined(MSDOS) || defined(unix)
   for (;;) {
     int nRead;
 
@@ -752,7 +571,6 @@ bool read_from_descriptor(DESCRIPTOR_DATA *d) {
       return FALSE;
     }
   }
-#endif
 
   d->inbuf[iStart] = '\0';
   return TRUE;
@@ -1271,9 +1089,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument) {
       break;
 
     case CON_GET_OLD_PASSWORD:
-#if defined(unix)
       write_to_buffer(d, "\n\r", 2);
-#endif
 
       if (strcmp(crypt(argument, ch->pcdata->pwd), ch->pcdata->pwd)) {
         write_to_buffer(d, "Wrong password.\n\r", 0);
@@ -1366,9 +1182,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument) {
       break;
 
     case CON_GET_NEW_PASSWORD:
-#if defined(unix)
       write_to_buffer(d, "\n\r", 2);
-#endif
 
       if (strlen(argument) < 5) {
         write_to_buffer(
@@ -1393,9 +1207,7 @@ void nanny(DESCRIPTOR_DATA *d, char *argument) {
       break;
 
     case CON_CONFIRM_NEW_PASSWORD:
-#if defined(unix)
       write_to_buffer(d, "\n\r", 2);
-#endif
 
       if (strcmp(crypt(argument, ch->pcdata->pwd), ch->pcdata->pwd)) {
         write_to_buffer(d, "Passwords don't match.\n\rRetype password: ", 0);
@@ -1757,10 +1569,6 @@ bool check_parse_name(char *name) {
    */
 
   if (strlen(name) < 2) return FALSE;
-
-#if defined(MSDOS)
-  if (strlen(name) > 8) return FALSE;
-#endif
 
   /*
    * Alphanumerics only.

--- a/src/db.c
+++ b/src/db.c
@@ -42,15 +42,6 @@
 
 extern int _filbuf args((FILE *));
 
-#if !defined(OLD_RAND)
-#if !defined(linux)
-long random();
-#endif
-void srandom(unsigned int);
-int getpid();
-time_t time(time_t *tloc);
-#endif
-
 /* externals for counting purposes */
 extern OBJ_DATA *obj_free;
 extern CHAR_DATA *char_free;

--- a/src/merc.h
+++ b/src/merc.h
@@ -55,27 +55,12 @@
 #define TRUE 1
 #endif
 
-#if defined(_AIX)
-#if !defined(const)
-#define const
-#endif
-typedef int sh_int;
-typedef int bool;
-#define unix
-#else
 typedef short int sh_int;
 typedef unsigned char bool;
-#endif
 
-/*
- * MacOS (modern)
- */
-#if defined(__MACH__)
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <unistd.h>
-#define unix
-#endif
 
 /*
  * Structure types.
@@ -1829,79 +1814,6 @@ extern TIME_INFO_DATA time_info;
 extern WEATHER_DATA weather_info;
 
 /*
- * OS-dependent declarations.
- * These are all very standard library functions,
- *   but some systems have incomplete or non-ansi header files.
- */
-#if defined(_AIX)
-char *crypt args((const char *key, const char *salt));
-#endif
-
-#if defined(apollo)
-int atoi args((const char *string));
-void *calloc args((unsigned nelem, size_t size));
-char *crypt args((const char *key, const char *salt));
-#endif
-
-#if defined(hpux)
-char *crypt args((const char *key, const char *salt));
-#endif
-
-#if defined(linux)
-char *crypt args((const char *key, const char *salt));
-#endif
-
-#if defined(macintosh)
-#define NOCRYPT
-#if defined(unix)
-#undef unix
-#endif
-#endif
-
-#if defined(MIPS_OS)
-char *crypt args((const char *key, const char *salt));
-#endif
-
-#if defined(MSDOS)
-#define NOCRYPT
-#if defined(unix)
-#undef unix
-#endif
-#endif
-
-#if defined(NeXT)
-char *crypt args((const char *key, const char *salt));
-#endif
-
-#if defined(sequent)
-char *crypt args((const char *key, const char *salt));
-int fclose args((FILE * stream));
-int fprintf args((FILE * stream, const char *format, ...));
-int fread args((void *ptr, int size, int n, FILE *stream));
-int fseek args((FILE * stream, long offset, int ptrname));
-void perror args((const char *s));
-int ungetc args((int c, FILE *stream));
-#endif
-
-#if defined(sun)
-char *crypt args((const char *key, const char *salt));
-int fclose args((FILE * stream));
-int fprintf args((FILE * stream, const char *format, ...));
-#if defined(SYSV)
-size_t fread args((void *ptr, size_t size, size_t n, FILE *stream));
-#elif !defined(__SVR4)
-int fread args((void *ptr, int size, int n, FILE *stream));
-#endif
-int fseek args((FILE * stream, long offset, int ptrname));
-void perror args((const char *s));
-int ungetc args((int c, FILE *stream));
-#endif
-
-#if defined(ultrix)
-char *crypt args((const char *key, const char *salt));
-#endif
-
-/*
  * The crypt(3) function is not available on some operating systems.
  * In particular, the U.S. Government prohibits its export from the
  *   United States to foreign countries.
@@ -1922,24 +1834,11 @@ char *crypt args((const char *key, const char *salt));
  *   so players can go ahead and telnet to all the other descriptors.
  * Then we close it whenever we need to open a file (e.g. a save file).
  */
-#if defined(macintosh)
-#define PLAYER_DIR "" /* Player files	*/
-#define TEMP_FILE "romtmp"
-#define NULL_FILE "proto.are" /* To reserve one stream */
-#endif
 
-#if defined(MSDOS)
-#define PLAYER_DIR "" /* Player files */
-#define TEMP_FILE "romtmp"
-#define NULL_FILE "nul" /* To reserve one stream */
-#endif
-
-#if defined(unix)
 #define PLAYER_DIR "../player/" /* Player files */
 #define GOD_DIR "../gods/"      /* list of gods */
 #define TEMP_FILE "../player/romtmp"
 #define NULL_FILE "/dev/null" /* To reserve one stream */
-#endif
 
 #define AREA_LIST "area.lst"  /* List of areas*/
 #define BUG_FILE "bugs.txt"   /* For 'bug' and bug()*/

--- a/src/music.h
+++ b/src/music.h
@@ -1,3 +1,5 @@
+#ifndef __MUSIC_H
+#define __MUSIC_H
 /***************************************************************************
  *  Original Diku Mud copyright (C) 1990, 1991 by Sebastian Hammer,	   *
  *  Michael Seifert, Hans Henrik St{rfeldt, Tom Madsen, and Katja Nyboe.   *
@@ -40,3 +42,4 @@ extern struct song_data song_table[MAX_SONGS];
 
 void song_update args((void));
 void load_songs args((void));
+#endif // __MUSIC_H

--- a/src/olc.h
+++ b/src/olc.h
@@ -1,3 +1,5 @@
+#ifndef __OLC_H
+#define __OLC_H
 /***************************************************************************
  *  File: olc.h                                                            *
  *                                                                         *
@@ -253,3 +255,4 @@ void free_obj_index args((OBJ_INDEX_DATA * pObj));
 MOB_INDEX_DATA *new_mob_index args((void));
 void free_mob_index args((MOB_INDEX_DATA * pMob));
 #undef ED
+#endif // __OLC_H

--- a/src/recycle.h
+++ b/src/recycle.h
@@ -1,3 +1,5 @@
+#ifndef __RECYCLE_H
+#define __RECYCLE_H
 /***************************************************************************
  *  Original Diku Mud copyright (C) 1990, 1991 by Sebastian Hammer,	   *
  *  Michael Seifert, Hans Henrik St{rfeldt, Tom Madsen, and Katja Nyboe.   *
@@ -110,3 +112,4 @@ void free_buf args((BUFFER * buffer));
 bool add_buf args((BUFFER * buffer, char *string));
 void clear_buf args((BUFFER * buffer));
 char *buf_string args((BUFFER * buffer));
+#endif // __RECYCLE_H

--- a/src/save.c
+++ b/src/save.c
@@ -95,7 +95,6 @@ void save_char_obj(CHAR_DATA *ch) {
 
   if (ch->desc != NULL && ch->desc->original != NULL) ch = ch->desc->original;
 
-#if defined(unix)
   /* create god log */
   if (IS_IMMORTAL(ch) || ch->level >= LEVEL_IMMORTAL) {
     fclose(fpReserve);
@@ -110,7 +109,6 @@ void save_char_obj(CHAR_DATA *ch) {
     fclose(fp);
     fpReserve = fopen(NULL_FILE, "r");
   }
-#endif
 
   fclose(fpReserve);
   sprintf(strsave, "%s%s", PLAYER_DIR, capitalize(ch->name));
@@ -463,7 +461,6 @@ bool load_char_obj(DESCRIPTOR_DATA *d, char *name) {
   found = FALSE;
   fclose(fpReserve);
 
-#if defined(unix)
   /* decompress if .gz file exists */
   sprintf(strsave, "%s%s%s", PLAYER_DIR, capitalize(name), ".gz");
   if ((fp = fopen(strsave, "r")) != NULL) {
@@ -477,7 +474,6 @@ bool load_char_obj(DESCRIPTOR_DATA *d, char *name) {
       log_string(buf);
     }
   }
-#endif
 
   sprintf(strsave, "%s%s", PLAYER_DIR, capitalize(name));
   if ((fp = fopen(strsave, "r")) != NULL) {


### PR DESCRIPTION
Nobody's running this on crusty old unix platforms or MS-DOS or pre-osx MacOS.

Remove the custom defines and such.